### PR TITLE
disable some flake8 rules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+ignore = E501,W291,W293,W292,E302,E305
+exclude = .git,__pycache__,env,venv


### PR DESCRIPTION
Relax or disable some flake8 rules
configure flake8 to ignore rules like E501 or W291 by creating a .flake8 config file.